### PR TITLE
Add reboot task

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -9,6 +9,7 @@ all:
     ansible_user: root
     enable_swap: false
     swap_size: 8192
+    reboot: false
   children:
     gaia:
       hosts:

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -227,5 +227,11 @@
     name: nginx-ssl
   when: gaiad_use_ssl_proxy | default(false) | bool
 
+
+- name: Rebooting the machine
+  include_role:
+    name: reboot
+  when: reboot | default(false) | bool
+
 # Misc output?
 # - name: print info about the node?

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Rebooting the machine
+  reboot:


### PR DESCRIPTION
This should be useful on first deploy as there are some system updates that needs to be applied and to make sure services starts on boot.

Should I default this task to run by default right now it is set to false?