### PR TITLE
Add gaiad to PATH

### DIFF
--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -397,7 +397,7 @@
     - gaiad_start
     - gaiad_restart
 
-- name: Add gaiad bin from cosmovisor to PATH 
+- name: Add gaiad bin from cosmovisor to PATH
   when: use_cosmovisor
   blockinfile:
     dest: '{{ gaiad_user_home }}/.bashrc'
@@ -407,7 +407,7 @@
     insertbefore: EOF
     create: yes
 
-- name: Add gaiad bin from go/bin to PATH 
+- name: Add gaiad bin from go/bin to PATH
   when: not use_cosmovisor
   blockinfile:
     dest: '{{ gaiad_user_home }}/.bashrc'

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -397,6 +397,26 @@
     - gaiad_start
     - gaiad_restart
 
+- name: Add gaiad bin from cosmovisor to PATH 
+  when: use_cosmovisor
+  blockinfile:
+    dest: '{{ gaiad_user_home }}/.bashrc'
+    block: |
+      export PATH="$PATH:{{ cosmovisor_home }}/current/bin"
+    marker: '# {mark} ANSIBLE MANAGED BLOCK - GAIAD PATH'
+    insertbefore: EOF
+    create: yes
+
+- name: Add gaiad bin from go/bin to PATH 
+  when: not use_cosmovisor
+  blockinfile:
+    dest: '{{ gaiad_user_home }}/.bashrc'
+    block: |
+      export PATH="$PATH:{{ gaiad_user_home }}/go/bin"
+    marker: '# {mark} ANSIBLE MANAGED BLOCK - GAIAD PATH'
+    insertbefore: EOF
+    create: yes
+
 - name: Set variables for api endpoint
   set_fact:
     endpoint_port: '{{api_port}}'


### PR DESCRIPTION
Update the PATH environment variable via .bashrc to make `gaiad` available to the `gaia` user right after running a play.

If `use_cosmovisor` is set to `true`:
Add `{{ cosmovisor_home }}/current/bin` to PATH

If `use_cosmovisor` is set to `false`:
Add `{{ gaiad_user_home }}/go/bin` to PATH