### PR TITLE
Auto populate trust height

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -23,6 +23,7 @@
       - build-essential
       - haveged
       - python3-openssl
+      - jq
 
 - name: Install basic utils
   apt:

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -62,6 +62,7 @@ statesync_trust_hash: ''
 statesync_trust_period: 168h0m0s
 statesync_discovery_time: 15s
 statesync_chunk_request_timeout: 10s
+statesync_auto_populate: true
 # TODO: Why does my config say 4 when it isn't default?
 statesync_chunk_fetchers: '4'
 

--- a/roles/gaia/files/get_trust_hash.sh
+++ b/roles/gaia/files/get_trust_hash.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Retrieve hash ID
+# $1: rpc address
+# $2: block height
+echo $(curl -s "$1/block?height=$2" | jq -r .result.block_id.hash)

--- a/roles/gaia/files/get_trust_height.sh
+++ b/roles/gaia/files/get_trust_height.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Retrieve trust height
+# $1: rpc address
+INTERVAL=1000
+LATEST_HEIGHT=$(curl -s $1/block | jq -r .result.block.header.height)
+BLOCK_HEIGHT=$(($LATEST_HEIGHT-$INTERVAL))
+echo $BLOCK_HEIGHT

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -397,7 +397,7 @@
     - gaiad_start
     - gaiad_restart
 
-- name: Add gaiad bin from cosmovisor to PATH 
+- name: Add gaiad bin from cosmovisor to PATH
   when: use_cosmovisor
   blockinfile:
     dest: '{{ gaiad_user_home }}/.bashrc'
@@ -407,7 +407,7 @@
     insertbefore: EOF
     create: yes
 
-- name: Add gaiad bin from go/bin to PATH 
+- name: Add gaiad bin from go/bin to PATH
   when: not use_cosmovisor
   blockinfile:
     dest: '{{ gaiad_user_home }}/.bashrc'

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -259,6 +259,31 @@
       exit 0
   become_user: "{{gaiad_user}}"
 
+# Get trust height automatically
+- name: install jq
+  when: statesync_enabled and statesync_auto_populate
+  apt:
+    pkg:
+      - jq
+
+- name: obtain trust height
+  when: statesync_enabled and statesync_auto_populate
+  script:
+    get_trust_height.sh {{ statesync_rpc_servers.split(',')[0] }}
+  register: trust_height
+
+- name: obtain trust height block hash ID
+  when: statesync_enabled and statesync_auto_populate
+  script:
+    get_trust_hash.sh {{ statesync_rpc_servers.split(',')[0] }} {{ trust_height.stdout[:-2] }}
+  register: trust_hash
+
+- name: set state sync variables
+  when: statesync_enabled and statesync_auto_populate
+  set_fact:
+    statesync_trust_height: "{{ trust_height.stdout[:-2] }}"
+    statesync_trust_hash: "{{ trust_hash.stdout[:-2] }}"
+
 # Config file generation
 - name: copy app.toml
   when: app_toml_file is defined

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -397,6 +397,26 @@
     - gaiad_start
     - gaiad_restart
 
+- name: Add gaiad bin from cosmovisor to PATH 
+  when: use_cosmovisor
+  blockinfile:
+    dest: '{{ gaiad_user_home }}/.bashrc'
+    block: |
+      export PATH="$PATH:{{ cosmovisor_home }}/current/bin"
+    marker: '# {mark} ANSIBLE MANAGED BLOCK - GAIAD PATH'
+    insertbefore: EOF
+    create: yes
+
+- name: Add gaiad bin from go/bin to PATH 
+  when: not use_cosmovisor
+  blockinfile:
+    dest: '{{ gaiad_user_home }}/.bashrc'
+    block: |
+      export PATH="$PATH:{{ gaiad_user_home }}/go/bin"
+    marker: '# {mark} ANSIBLE MANAGED BLOCK - GAIAD PATH'
+    insertbefore: EOF
+    create: yes
+
 - name: Set variables for api endpoint
   set_fact:
     endpoint_port: '{{api_port}}'

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -260,12 +260,6 @@
   become_user: "{{gaiad_user}}"
 
 # Get trust height automatically
-- name: install jq
-  when: statesync_enabled and statesync_auto_populate
-  apt:
-    pkg:
-      - jq
-
 - name: obtain trust height
   when: statesync_enabled and statesync_auto_populate
   script:


### PR DESCRIPTION
This `gaia` role will run two scripts to set a trust height and corresponding hash ID for statesync.
a.
- `statesync_enabled` must be set to `true`.
- The first server listed in the `statesync_rpc_servers` variable is used to obtain the data.
- If the user wants to provide a specific trust height and hash ID, they need to set `statesync_auto_populate` to `false`.

### Testing

Set the host address in `examples/inventory-theta.yml` and run:
```
ansible-playbook gaia.yml -i examples/inventory-theta.yml
```