### PR TITLE
Patch genesis for governance testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ ansible-playbook gaia.yml -i inventory.yml
 |-------------------|---------------------------------------------------------------|--------------------------------------|
 | `gaia_version`    | Gaia repo tag, commit, or branch to check out and compile     | `release/v6.0.4`                     |
 | `gaia_repository` | Gaia source repo                                              | `https://github.com/cosmos/gaia.git` |
-| `chain_id`        | Sets the chain ID                                             | `my-testnet`                       |
+| `chain_id`        | Sets the chain ID                                             | `my-testnet`                         |
 | `use_cosmovisor`  | Uses cosmovisor when `true`, raw `gaiad` service when `false` | `true`                               |
-| `genesis_url` | URL to download the gzipped genesis file from | `""`
+| `genesis_url` | URL to download the gzipped genesis file from | `""` |
 | `genesis_file` | File path to the genesis file* | `""` |
 | `addrbook_url` | URL to download the addrbook.json file from. e.g. [via quicksync.io](https://quicksync.io/addrbook.cosmos.json) | `""`  |
 | `addrbook_file` | File path to the addrbook.json file to use | `""` |
 | `p2p_pex` | p2p peer exchange is enabled | `true`  | 
 | `p2p_persistent_peers` | list of peers to connect to | |
 | `fast_sync`| Enable/disable fast sync | `true` |
+| `gov_testing` | Set minimum deposit to `1` and voting period to `5s` when `true` | `true` |
 | `enable_swap` |Enable/disable swap | `false`  |
 | `swap_size` |  Swap file size in MB (8 GB default) | `8192` |
 | `cosmovisor_skip_backup` | Skip Cosmovisor backups | `true` |

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ ansible-playbook gaia.yml -i inventory.yml
 
 | Variable          | Description                                                   | Example Value                        |
 |-------------------|---------------------------------------------------------------|--------------------------------------|
-| `gaia_version`    | Gaia repo tag, commit, or branch to check out and compile     | `release/v6.0.4`                     |
-| `gaia_repository` | Gaia source repo                                              | `https://github.com/cosmos/gaia.git` |
+| `gaiad_version`    | Gaia repo tag, commit, or branch to check out and compile     | `release/v6.0.4`                     |
+| `gaiad_repository` | Gaia source repo                                              | `https://github.com/cosmos/gaia.git` |
 | `chain_id`        | Sets the chain ID                                             | `my-testnet`                         |
 | `use_cosmovisor`  | Uses cosmovisor when `true`, raw `gaiad` service when `false` | `true`                               |
 | `genesis_url` | URL to download the gzipped genesis file from | `""` |
@@ -48,7 +48,7 @@ ansible-playbook gaia.yml -i inventory.yml
 | `p2p_pex` | p2p peer exchange is enabled | `true`  | 
 | `p2p_persistent_peers` | list of peers to connect to | |
 | `fast_sync`| Enable/disable fast sync | `true` |
-| `gov_testing` | Set minimum deposit to `1` and voting period to `5s` when `true` | `true` |
+| `gaiad_gov_testing` | Set minimum deposit to `1` and voting period to `5s` when `true` | `true` |
 | `enable_swap` |Enable/disable swap | `false`  |
 | `swap_size` |  Swap file size in MB (8 GB default) | `8192` |
 | `cosmovisor_skip_backup` | Skip Cosmovisor backups | `true` |

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -9,6 +9,8 @@ gaiad_version: v7.0.0
 gaiad_repository: https://github.com/cosmos/gaia.git
 gaiad_bin: "{{ gaiad_user_home }}/go/bin/gaiad"
 gaiad_service_name: "gaiad"
+gaiad_gov_testing: false
+gaiad_voting_period: 5s
 chain_id: "theta-devnet"
 
 # Default vaiables for creating a validator

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -165,6 +165,14 @@
     gaiad collect-gentxs --home {{gaiad_home}}
   become_user: "{{gaiad_user}}"
 
+- name: patch genesis file with minimum deposit and short voting period
+  when: gaiad_gov_testing
+  shell: |
+    cd {{gaiad_home}}/config
+    jq '.app_state.gov.deposit_params.min_deposit[0].amount |= "1"' genesis.json > temp.json
+    jq '.app_state.gov.voting_params.voting_period |= "{{ gaiad_voting_period }}"' temp.json > genesis.json
+    rm temp.json
+
 - name: Check cosmovisor version
   when: use_cosmovisor
   shell: |


### PR DESCRIPTION
Added a task to the `gaia` role to update these governance variables in a genesis file:

If `gaiad_gov_testing` is set to true:
`voting_period`: `5s`
`minimum_deposit`: `1`

The voting period is set through the `gaiad_voting_period` variable, which has a default of 5s.

If we want to test software upgrade proposals through CI we need to have something like this available.