### PR TITLE
Add REST faucet feature

### DIFF
--- a/.github/workflows/test-gaia-versions.yml
+++ b/.github/workflows/test-gaia-versions.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Check cosmovisor service
         run: systemctl status cosmovisor
       - name: Check blocks are being produced
-        run: tests/test_block_production.sh 127.0.0.1 26657
+        run: tests/test_block_production.sh 127.0.0.1 26657 10
       - name: Get RAM usage while gaiad is running
         run: free -m
 

--- a/.github/workflows/test-gaia-versions.yml
+++ b/.github/workflows/test-gaia-versions.yml
@@ -117,6 +117,6 @@ jobs:
       - name: Check cosmovisor service
         run: systemctl status cosmovisor
       - name: Check blocks are being produced
-        run: tests/test_block_production.sh 127.0.0.1 26657
+        run: tests/test_block_production.sh 127.0.0.1 26657 10
       - name: Test software upgrade
         run: tests/test_software_upgrade.sh 127.0.0.1 26657 ${{ matrix.upgrade_version }}

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ The operation will apply to all the nodes in the inventory:
 - Systemd services: `roles/gaia/templates/`
 - To add a variable to the gaia config files, add it to:
   - `roles/gaia/templates/ansible_vars.json.j2`  
-  and
-  - `roles/gaia/vars/main.yml`
 
 ## Code Standards
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,8 +39,7 @@ Set up a node with a single validator account.
 * **Inventory file:** [`inventory-local.yml`](inventory-local.yml)
 * **Chain ID:** `my-testnet`
 * **Gaia version:** `v7.0.0`
-
-The validator mnemonic will be saved to `/home/gaia/.gaia/create_validator.log` in the host.
+* **Faucet REST server**
 
 ### Requirements
 
@@ -52,6 +51,10 @@ The validator mnemonic will be saved to `/home/gaia/.gaia/create_validator.log` 
 ```
 ansible-playbook gaia.yml -i examples/inventory-local.yml
 ```
+
+- The validator address and mnemonic will be saved to `/home/gaia/.gaia/create_validator.log` in the host.
+- The faucet address and mnemonic will be saved to `/home/gaia/.gaia/faucet.json` in the host.
+- The faucet REST server will listen on port `8000` by default. This can be adjusted in the [faucet.service.j2](/roles/gaia/templates/faucet.service.j2) template.
 
 ## Start a Local Testnet Using a Modified Genesis File
 

--- a/examples/inventory-local.yml
+++ b/examples/inventory-local.yml
@@ -5,6 +5,7 @@ all:
     gaiad_home_autoclear: true
     gaiad_version: v7.0.0
     gaiad_create_validator: true
+    faucet_enabled: true
   children:
     gaia:
       hosts:

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -10,7 +10,7 @@ gaiad_repository: https://github.com/cosmos/gaia.git
 gaiad_bin: "{{ gaiad_user_home }}/go/bin/gaiad"
 gaiad_service_name: "gaiad"
 gaiad_gov_testing: false
-gaiad_voting_period: 5s
+gaiad_voting_period: 10s
 chain_id: "theta-devnet"
 
 # Default vaiables for creating a validator

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -112,6 +112,10 @@ statesync_snapshot_keep_recent: 2
 client_keyring_backend: os
 client_broadcast_mode: sync
 
+### Faucet settings
+faucet_enabled: false
+faucet_service_name: token-faucet
+
 ### node exporter config
 node_exporter_port: 9100
 

--- a/roles/gaia/tasks/faucet.yml
+++ b/roles/gaia/tasks/faucet.yml
@@ -1,3 +1,4 @@
+---
 - name: create faucet account
   when: faucet_enabled
   shell: |
@@ -10,8 +11,8 @@
 - name: save faucet name, address, and mnemonic
   when: faucet_enabled
   copy:
-      content: "{{create_faucet_output.stderr}}"
-      dest: "{{gaiad_home}}/faucet.json"
+    content: "{{create_faucet_output.stderr}}"
+    dest: "{{gaiad_home}}/faucet.json"
   become_user: "{{gaiad_user}}"
 
 - name: checkout rest faucet repo

--- a/roles/gaia/tasks/faucet.yml
+++ b/roles/gaia/tasks/faucet.yml
@@ -1,0 +1,77 @@
+- name: create faucet account
+  when: faucet_enabled
+  shell: |
+    PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+    gaiad keys add faucet --home {{gaiad_home}} --keyring-backend {{gaiad_validator_keyring}} --output json
+    gaiad add-genesis-account faucet 1000000000000stake --home {{gaiad_home}} --keyring-backend="{{gaiad_validator_keyring}}"
+  register: create_faucet_output
+  become_user: "{{gaiad_user}}"
+
+- name: save faucet name, address, and mnemonic
+  when: faucet_enabled
+  copy:
+      content: "{{create_faucet_output.stderr}}"
+      dest: "{{gaiad_home}}/faucet.json"
+  become_user: "{{gaiad_user}}"
+
+- name: checkout rest faucet repo
+  when: faucet_enabled
+  git:
+    repo: 'https://github.com/hyphacoop/cosmos-rest-faucet.git'
+    dest: "{{gaiad_user_home}}/cosmos-rest-faucet"
+    version: "v0.2.0"
+    force: yes
+  become_user: "{{gaiad_user}}"
+
+- name: install python for faucet
+  when: faucet_enabled
+  apt:
+    pkg:
+      - python3
+      - python3-venv
+      - python3-pip
+      - python-is-python3
+
+- name: set up python virtual environment
+  when: faucet_enabled
+  shell: |
+    cd {{gaiad_user_home}}/cosmos-rest-faucet
+    python -m venv .env
+  become_user: "{{gaiad_user}}"
+
+- name: install faucet dependencies
+  when: faucet_enabled
+  pip:
+    requirements: "{{gaiad_user_home}}/cosmos-rest-faucet/requirements.txt"
+    virtualenv: "{{gaiad_user_home}}/cosmos-rest-faucet/.env"
+  become_user: "{{gaiad_user}}"
+
+- name: set faucet address
+  when: faucet_enabled
+  shell: |
+    jq '.address' {{gaiad_home}}/faucet.json
+  register: faucet_address
+  become_user: "{{gaiad_user}}"
+
+- name: configure faucet
+  when: faucet_enabled
+  template:
+    src: faucet_config.toml.j2
+    dest: "{{gaiad_user_home}}/cosmos-rest-faucet/config.toml"
+
+- name: configure faucet service
+  when: faucet_enabled
+  template:
+    src: faucet.service.j2
+    dest: "/etc/systemd/system/{{faucet_service_name}}.service"
+
+- name: Start faucet service
+  when: faucet_enabled
+  systemd:
+    daemon_reload: true
+    state: restarted
+    enabled: true
+    name: "{{faucet_service_name}}"
+  tags:
+    - gaiad_start
+    - gaiad_restart

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -69,6 +69,18 @@
     - gaiad_stop
     - gaiad_restart
 
+- name: Stop existing faucet systemd service
+  when: >
+    faucet_enabled and (
+    (faucet_service_name in ansible_facts.services) or
+    ((faucet_service_name + '.service') in ansible_facts.services))
+  systemd:
+    state: stopped
+    name: "{{faucet_service_name}}"
+  tags:
+    - gaiad_stop
+    - gaiad_restart
+
 - name: Check golang version
   shell: |
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
@@ -208,6 +220,10 @@
     gaiad gentx validator {{gaiad_gentx_validator_stake}} --keyring-backend="{{gaiad_validator_keyring}}" --home {{gaiad_home}} --chain-id {{chain_id}}
     gaiad collect-gentxs --home {{gaiad_home}}
   become_user: "{{gaiad_user}}"
+
+- name: set up faucet
+  when: faucet_enabled
+  import_tasks: faucet.yml
 
 - name: patch genesis file with minimum deposit and short voting period
   when: gaiad_gov_testing

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -192,16 +192,17 @@
   shell: |
     cd $HOME
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
-    gaiad keys add validator --keyring-backend="test" --home {{gaiad_home}}
+    gaiad keys add validator --keyring-backend {{gaiad_validator_keyring}} --home {{gaiad_home}} --output json
     gaiad add-genesis-account validator {{gaiad_validator_coins}} --home {{gaiad_home}} --keyring-backend="{{gaiad_validator_keyring}}"
   register: gaiad_create_validator_output
   become_user: "{{gaiad_user}}"
 
-- name: saving validator output
+- name: save validator name, address, and mnemonic
   when: gaiad_create_validator_output
   copy:
-    content="{{gaiad_create_validator_output}}"
-    dest="{{gaiad_home}}/create_validator.log"
+    content="{{gaiad_create_validator_output.stderr}}"
+    dest="{{gaiad_home}}/validator.json"
+  become_user: "{{gaiad_user}}"
 
 - name: create genesis accounts
   when: gaiad_airdrop and gaiad_create_validator

--- a/roles/gaia/templates/faucet.service.j2
+++ b/roles/gaia/templates/faucet.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description="Cosmos REST faucet"
+
+[Service]
+User={{gaiad_user}}
+Environment="PATH={{gaiad_home}}/cosmovisor/current/bin"
+WorkingDirectory={{gaiad_user_home}}/cosmos-rest-faucet
+ExecStart={{gaiad_user_home}}/cosmos-rest-faucet/.env/bin/hypercorn cosmos_rest_faucet:app -b 0.0.0.0:8000
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/gaia/templates/faucet_config.toml.j2
+++ b/roles/gaia/templates/faucet_config.toml.j2
@@ -1,0 +1,19 @@
+# Cosmos REST Faucet configuration
+
+gaia_home_folder = "{{gaiad_home}}"
+transactions_log = "transactions.csv"
+request_timeout    = "86400"
+
+[cosmos]
+prefix         = "cosmos"
+denomination   = "stake"
+
+[testnets]
+    [testnets.{{chain_id}}]
+    node_url = "http://localhost:26657"
+    chain_id = "{{chain_id}}"
+    faucet_address = {{faucet_address.stdout}}
+    daily_cap = "500000000"
+    amount_to_send = "1000000"
+    tx_fees = "500"
+

--- a/tests/test_block_production.sh
+++ b/tests/test_block_production.sh
@@ -3,23 +3,10 @@
 
 gaia_host=$1
 gaia_port=$2
+stop_height=$3
 
-# Wait for gaia service to respond
-attempt_counter=0
-max_attempts=60
-until $(curl --output /dev/null --silent --head --fail http://$gaia_host:$gaia_port)
-do
-    if [ ${attempt_counter} -gt ${max_attempts} ]
-    then
-        echo ""
-        echo "Tried connecting to gaiad for $attempt_counter times. Exiting."
-        exit 1
-    fi
-
-    printf '.'
-    attempt_counter=$(($attempt_counter+1))
-    sleep 1
-done
+# Test gaia response
+tests/test_gaia_response.sh $gaia_host $gaia_port
 
 # Get the current gaia version from the API
 gaiad_version=$(curl -s http://$gaia_host:$gaia_port/abci_info | jq -r .result.response.version)
@@ -27,8 +14,6 @@ gaiad_version=$(curl -s http://$gaia_host:$gaia_port/abci_info | jq -r .result.r
 # Check if gaia is producing blocks
 test_counter=0
 max_tests=60
-cur_height=$(curl -s http://$gaia_host:$gaia_port/block | jq -r .result.block.header.height)
-let stop_height=cur_height+10
 echo "Current gaiad version: $gaiad_version"
 echo "Block height: $cur_height"
 echo "Waiting to reach block height $stop_height..."

--- a/tests/test_gaia_response.sh
+++ b/tests/test_gaia_response.sh
@@ -1,0 +1,22 @@
+#!/bin/bash 
+# Test gaia is online.
+
+gaia_host=$1
+gaia_port=$2
+
+# Waiting until gaiad responds
+attempt_counter=0
+max_attempts=60
+echo "Waiting for gaia to come back online..."
+until $(curl --output /dev/null --silent --head --fail http://$gaia_host:$gaia_port)
+do
+    if [ ${attempt_counter} -gt ${max_attempts} ]
+    then
+        echo ""
+        echo "Tried connecting to gaiad for $attempt_counter times. Exiting."
+        exit 3
+    fi
+    printf '.'
+    attempt_counter=$(($attempt_counter+1))
+    sleep 1
+done

--- a/tests/test_software_upgrade.sh
+++ b/tests/test_software_upgrade.sh
@@ -72,7 +72,7 @@ if [ -n "$upgrade_name" ]; then
 
     # Wait for the voting period to be over
     echo "Waiting for the voting period to end..."
-    sleep $voting_waiting_time-6
+    sleep $[$voting_waiting_time-6]
 
     echo "Upgrade proposal status:"
     gaiad q gov proposal 1 --output json | jq '.status'


### PR DESCRIPTION
- A faucet server can be started as part of the play by setting the `faucet_enabled` variable to `true`.
- Updated examples README to mention the faucet feature that is now enabled in the `inventory-local.yml` example.
- Cleaned up the GH actions workflow tests to remove code duplication
- When a validator is created as part of the play, the data is now saved in JSON format in the Gaia home folder.

To test, run the [local testnet example](https://github.com/hyphacoop/cosmos-ansible/tree/feature/rest-faucet/examples#start-a-local-testnet).