### PR TITLE
Fix "when" flag for gaiad_create_validator

### DIFF
--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -198,7 +198,7 @@
   become_user: "{{gaiad_user}}"
 
 - name: save validator name, address, and mnemonic
-  when: gaiad_create_validator_output
+  when: gaiad_create_validator
   copy:
     content="{{gaiad_create_validator_output.stderr}}"
     dest="{{gaiad_home}}/validator.json"


### PR DESCRIPTION
The task `save validator name, address, and mnemonic` in the gaia role uses the wrong `when` value, which makes it run even when no validator is created.