### PR TITLE
Replace 'sentry' with 'state-sync' in theta example inventory file

### DIFF
--- a/examples/inventory-theta.yml
+++ b/examples/inventory-theta.yml
@@ -21,4 +21,4 @@ all:
         theta.testnet.com:
           fast_sync: true
           statesync_enabled: true
-          statesync_rpc_servers: 'rpc.sentry-01.theta-testnet.polypore.xyz:26657,rpc.sentry-02.theta-testnet.polypore.xyz:26657'
+          statesync_rpc_servers: 'rpc.state-sync-01.theta-testnet.polypore.xyz:26657,rpc.state-sync-02.theta-testnet.polypore.xyz:26657'


### PR DESCRIPTION
Replaces sentry nodes with state sync ones in the theta testnet inventory file.