### PR TITLE
Add "happy path" transaction tests

### DIFF
--- a/.github/workflows/test-gaia-versions.yml
+++ b/.github/workflows/test-gaia-versions.yml
@@ -89,6 +89,8 @@ jobs:
         run: systemctl status cosmovisor
       - name: Check blocks are being produced
         run: tests/test_block_production.sh 127.0.0.1 26657 10
+      - name: Happy path - transaction testing
+        run: tests/test_tx_fresh.sh
       - name: Get RAM usage while gaiad is running
         run: free -m
 
@@ -123,3 +125,5 @@ jobs:
         run: tests/test_block_production.sh 127.0.0.1 26657 10
       - name: Test software upgrade
         run: tests/test_software_upgrade.sh 127.0.0.1 26657 ${{ matrix.upgrade_version }}
+      - name: Happy path - transaction testing
+        run: tests/test_tx_fresh.sh

--- a/tests/test_tx_fresh.sh
+++ b/tests/test_tx_fresh.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Test transactions with a fresh state.
+# This script assumes:
+# - a faucet and validator have been created as part of the play
+# - the bond denom is stake
+# - the home folder is ~/.gaia
+# - gaiad is in the PATH environment variable
+
+check_code()
+{
+  txhash=$1
+  code=$(gaiad q tx $txhash -o json | jq '.code')
+  if [ $code -eq 0 ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Recover faucet address
+faucet=$(jq -r '.address' ~/.gaia/faucet.json)
+echo "faucet has address $faucet."
+
+# Recover validator self-delegation and operator addresses
+val_self_del=$(jq -r '.address' ~/.gaia/validator.json)
+val1=$(echo $(gaiad q staking delegations $val_self_del -o json) | jq -r '.delegation_responses[0].delegation.validator_address')
+echo "validator has self-delegation address $val_self_del."
+echo "validator has operator address $val1."
+
+# Create test account
+echo $(gaiad keys add test-account --keyring-backend test --output json 2>&1) > test_account.json
+test_account=$(jq -r '.address' ./test_account.json)
+echo "test-account has address $test_account."
+
+# Test tx send
+echo "Sending funds from faucet to test account..."
+TXHASH=$(gaiad tx bank send $faucet $test_account 5000100stake --from $faucet --keyring-backend test --fees 1stake --chain-id my-testnet -y -o json | jq '.txhash' | tr -d '"')
+echo $TXHASH
+echo "Waiting for transaction to go on chain..."
+sleep 6
+check_code $TXHASH
+
+# Test delegation
+echo "Delgating funds from test account to validator..."
+# Delegate from test-account to validator
+TXHASH=$(gaiad tx staking delegate $val1 1000000stake --from test-account --keyring-backend test --fees 1stake --chain-id my-testnet -y -o json | jq '.txhash' | tr -d '"')
+echo "Waiting for transaction to go on chain..."
+sleep 6
+check_code $TXHASH
+
+# Test withdrawing rewards
+starting_balance=$(gaiad q bank balances $test_account -o json | jq -r '.balances[0].amount')
+balance_denom=$(gaiad q bank balances $test_account -o json | jq -r '.balances[0].denom')
+
+echo "Withdrawing rewards for test account..."
+TXHASH=$(gaiad tx distribution withdraw-all-rewards --from $test_account --keyring-backend test --fees 1stake --chain-id my-testnet -y -o json | jq '.txhash' | tr -d '"')
+# Wait for rewards to accumulate
+echo "Waiting for transaction to go on chain..."
+sleep 6
+check_code $TXHASH
+
+# Check the test-account funds
+ending_balance=$(gaiad q bank balances $test_account -o json | jq -r '.balances[0].amount')
+delta=$[ $ending_balance - $starting_balance]
+if [ $delta -gt 0 ]
+then
+    echo "$delta$balance_denom were withdrawn successfully."
+else
+    echo "Rewards could not be withdrawn."
+    exit 1
+fi

--- a/tests/test_tx_fresh.sh
+++ b/tests/test_tx_fresh.sh
@@ -5,7 +5,6 @@
 # - a faucet and validator have been created as part of the play
 # - the bond denom is stake
 # - the home folder is ~/.gaia
-# - gaiad is in the PATH environment variable
 
 check_code()
 {
@@ -18,6 +17,9 @@ check_code()
     return 1
   fi
 }
+
+# Add gaiad to PATH
+export PATH="$PATH:~/.gaia/cosmovisor/current/bin"
 
 # Recover faucet address
 faucet=$(jq -r '.address' ~/.gaia/faucet.json)

--- a/tests/test_tx_fresh.sh
+++ b/tests/test_tx_fresh.sh
@@ -47,9 +47,9 @@ check_code $TXHASH
 # Test delegation
 echo "Delgating funds from test account to validator..."
 # Delegate from test-account to validator
-TXHASH=$(gaiad tx staking delegate $val1 1000000stake --from test-account --keyring-backend test --fees 1stake --chain-id my-testnet -y -o json | jq '.txhash' | tr -d '"')
+TXHASH=$(gaiad tx staking delegate $val1 4000000stake --from test-account --keyring-backend test --fees 1stake --chain-id my-testnet -y -o json | jq '.txhash' | tr -d '"')
 echo "Waiting for transaction to go on chain..."
-sleep 6
+sleep 12
 check_code $TXHASH
 
 # Test withdrawing rewards


### PR DESCRIPTION
Updated GitHub Actions workflow to test the following transactions:
- `tx bank send`
- `tx staking delegate`
- `tx distribution withdraw-all-rewards`

Closes #102 