### PR TITLE
Add target var

### DIFF
--- a/.github/workflows/test-gaia-versions.yml
+++ b/.github/workflows/test-gaia-versions.yml
@@ -81,10 +81,8 @@ jobs:
 
       - name: Configure ansible.cfg
         run: echo "transport = local" >> ansible.cfg
-      - name: Configure inventory
-        run: "sed 's/root@testnet.com:/local:/g' examples/inventory-local.yml > inventory.yml"
       - name: Run playbook
-        run: ansible-playbook gaia.yml -i inventory.yml --extra-vars "reboot=false gaiad_version=${{ matrix.gaia_version }} gaiad_home={{ gaiad_user_home }}/.gaia gaiad_gov_testing=true gaiad_user=runner"
+        run: ansible-playbook gaia.yml -i examples/inventory-local.yml --extra-vars "target=local reboot=false gaiad_version=${{ matrix.gaia_version }} gaiad_home={{ gaiad_user_home }}/.gaia gaiad_gov_testing=true gaiad_user=runner"
       - name: Check cosmovisor service
         run: systemctl status cosmovisor
       - name: Check blocks are being produced
@@ -115,10 +113,8 @@ jobs:
 
       - name: Configure ansible.cfg
         run: echo "transport = local" >> ansible.cfg
-      - name: Configure inventory
-        run: "sed 's/root@testnet.com:/local:/g' examples/inventory-local.yml > inventory.yml"
       - name: Run playbook
-        run: ansible-playbook gaia.yml -i inventory.yml --extra-vars "reboot=false gaiad_version=${{ matrix.gaia_version }} gaiad_home={{ gaiad_user_home }}/.gaia gaiad_gov_testing=true gaiad_user=runner"
+        run: ansible-playbook gaia.yml -i examples/inventory-local.yml --extra-vars "target=local reboot=false gaiad_version=${{ matrix.gaia_version }} gaiad_home={{ gaiad_user_home }}/.gaia gaiad_gov_testing=true gaiad_user=runner"
       - name: Check cosmovisor service
         run: systemctl status cosmovisor
       - name: Check blocks are being produced

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ An Ansible toolkit for Cosmos networks. It allows your control node to:
 Set the appropriate variables in `inventory.yml` and run:
 
 ```
-ansible-playbook gaia.yml -i inventory.yml
+ansible-playbook gaia.yml -i inventory.yml -e 'target=SERVER_IP_OR_DOMAIN'
 ```
 
-- Use the `--extra-vars` option to override the default variables on the command line.
+- Use the `--extra-vars` or `-e` option to override the default variables on the command line.
 - See the [examples](examples/) for more command, playbook, and configuration options.
 - Visit the [Cosmos testnets repo](https://github.com/cosmos/testnets) for more information.
 
@@ -73,10 +73,12 @@ ansible-playbook gaia.yml -i inventory.yml
 `gaia_control.py` calls `ansible-playbook` using tags to run only part of the `gaia` playbook:
 
 ```
-./gaia-control.py [-i inventory] operation
+./gaia-control.py [-i inventory] [-t target] operation
 ```
 
 The inventory argument is optional and defaults to `inventory.yml` (e.g. `./gaia-control.py restart`).
+
+The target option is the server IP or domain.
 
 The operation will apply to all the nodes in the inventory:
 - `restart` restarts the gaiad/cosmovisor service

--- a/examples/inventory-dev.yml
+++ b/examples/inventory-dev.yml
@@ -20,7 +20,7 @@ all:
   children:
     gaia:
       hosts:
-        dev.testnet.com:
+        "{{ target }}":
           ansible_user: root
           gaiad_create_validator: true
           gaiad_airdrop: true

--- a/examples/inventory-local-genesis.yml
+++ b/examples/inventory-local-genesis.yml
@@ -8,6 +8,6 @@ all:
   children:
     gaia:
       hosts:
-        root@testnet.com:
+        "{{ target }}":
           fast_sync: false
           priv_validator_key_file: "priv_validator_key.json"

--- a/examples/inventory-local.yml
+++ b/examples/inventory-local.yml
@@ -9,6 +9,6 @@ all:
   children:
     gaia:
       hosts:
-        root@testnet.com:
+        "{{ target }}":
           fast_sync: false
           chain_id: my-testnet

--- a/examples/inventory-mainnet.yml
+++ b/examples/inventory-mainnet.yml
@@ -21,7 +21,7 @@ all:
   children:
     gaia:
       hosts:
-        cosmoshub-4.mainnet.com:
+        "{{ target }}":
           fast_sync: true
           statesync_enabled: true
           statesync_rpc_servers: 'https://rpc.cosmos.network:443,https://rpc.cosmos.network:443'

--- a/examples/inventory-theta.yml
+++ b/examples/inventory-theta.yml
@@ -18,7 +18,7 @@ all:
   children:
     gaia:
       hosts:
-        theta.testnet.com:
+        "{{ target }}":
           fast_sync: true
           statesync_enabled: true
           statesync_rpc_servers: 'rpc.state-sync-01.theta-testnet.polypore.xyz:26657,rpc.state-sync-02.theta-testnet.polypore.xyz:26657'

--- a/gaia_control.py
+++ b/gaia_control.py
@@ -2,8 +2,9 @@
 
 """
 Ansible-backed node management operations:
-./gaia-control.py [-i <inventory file>] <operation>
+./gaia-control.py [-i <inventory file>] [-t target] <operation>
 -i is optional, it defaults to inventory.yml
+The target option is the server IP or domain
 Operations:
 restart: restarts the gaiad/cosmovisor service
 stop: stops the gaiad/cosmovisor service
@@ -20,12 +21,16 @@ parser = argparse.ArgumentParser(description='Single-command node management.')
 parser.add_argument('-i', metavar='inventory', help='inventory file (default: inventory.yml)',
                     required=False,
                     default='inventory.yml')
+parser.add_argument('-t', metavar='target', help='target server',
+                    required=False,
+                    default='')
 parser.add_argument('operation', help='the operation to perform')
 
 args = parser.parse_args()
 
 operation = args.operation
 inventory = args.i
+target = args.t
 
 if operation == "restart":
     print(os.popen("ansible-playbook gaia.yml -i " +
@@ -34,12 +39,12 @@ if operation == "restart":
 
 if operation == "stop":
     print(os.popen("ansible-playbook gaia.yml -i " +
-                   inventory + " --tags 'gaiad_stop'").read())
+                   inventory + " -e 'target=" + target + "' --tags 'gaiad_stop'").read())
     sys.exit(0)
 
 if operation == "start":
     print(os.popen("ansible-playbook gaia.yml -i " +
-                   inventory + " --tags 'gaiad_start'").read())
+                   inventory + " -e 'target=" + target + "' --tags 'gaiad_start'").read())
     sys.exit(0)
 
 if operation == "reset":
@@ -49,7 +54,7 @@ if operation == "reset":
     if answer.lower() in ["yes"]:
         print(os.popen("ansible-playbook gaia.yml -i " +
                        inventory +
-                       " --extra-vars 'gaiad_unsafe_reset=true' "
+                       " --extra-vars 'gaiad_unsafe_reset=true target=" + target + "' "
                        " --tags 'gaiad_stop,gaiad_reset,gaiad_start'").read())
         sys.exit(0)
     else:
@@ -58,7 +63,7 @@ if operation == "reset":
 
 if operation == "reboot":
     print(os.popen("ansible-playbook gaia.yml -i " + inventory +
-                   " --extra-vars 'reboot=true' --tags 'reboot'").read())
+                   " --extra-vars 'reboot=true target=" + target + "' --tags 'reboot'").read())
     sys.exit(0)
 
 else:


### PR DESCRIPTION
This adds a `target` variable, intended to be specified on the CLI. For single node setups this removes the need to edit the inventory file, which is cleaner and easier.