### PR TITLE
Add missing brackets to reset tasks

### DIFF
--- a/examples/inventory-local.yml
+++ b/examples/inventory-local.yml
@@ -2,10 +2,8 @@
 # yamllint disable rule:line-length
 all:
   vars:
-    gaiad_home_autoclear: true
-    gaiad_version: v7.0.0
-    gaiad_create_validator: true
-    faucet_enabled: true
+    gaiad_home_autoclear: false
+    gaiad_version: v7.0.1
     ansible_user: root
   children:
     gaia:

--- a/examples/inventory-local.yml
+++ b/examples/inventory-local.yml
@@ -2,8 +2,10 @@
 # yamllint disable rule:line-length
 all:
   vars:
-    gaiad_home_autoclear: false
-    gaiad_version: v7.0.1
+    gaiad_home_autoclear: true
+    gaiad_version: v7.0.0
+    gaiad_create_validator: true
+    faucet_enabled: true
     ansible_user: root
   children:
     gaia:

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -155,7 +155,7 @@
   become_user: "{{gaiad_user}}"
 
 - name: reset gaiad database (command for <v7.0.1)
-  when: gaiad_unsafe_reset and (major_version|int == 7 and patch_version|int == 0) or major_version|int < 7
+  when: gaiad_unsafe_reset and ((major_version|int == 7 and patch_version|int == 0) or major_version|int < 7)
   shell: |
     cd $HOME
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
@@ -165,7 +165,7 @@
     - gaiad_reset
 
 - name: reset gaiad database (command for >v7.0.0)
-  when: (major_version|int == 7 and patch_version|int >= 1) or major_version|int > 7
+  when: gaiad_unsafe_reset and ((major_version|int == 7 and patch_version|int >= 1) or major_version|int > 7)
   shell: |
     cd $HOME
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin


### PR DESCRIPTION
Closes #133 
Tested the following progression of several gaia versions on a local testnet:
v6.0.3 -> v6.0.4 -> v7.0.0 -> v7.0.2 -> v7.0.1
With `gaiad_unsafe_reset` and `gaiad_home_autoclear` set to false, the block height kept increasing from one version to the next one.