### PR TITLE
Download binary from REPO instead of building

### DIFF
--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -7,8 +7,8 @@ gaiad_home_autoclear: false
 gaiad_unsafe_reset: false
 gaiad_version: v7.0.0
 gaiad_repository: https://github.com/cosmos/gaia.git
-gaiad_binary_release: "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-{{ gaiad_version }}-linux-amd64"
-gaiad_binary_source: build
+gaiad_binary_release: "https://github.com/cosmos/gaia/releases/download/{{ gaiad_version }}/gaiad-{{ gaiad_version }}-linux-amd64"
+gaiad_binary_source: "build"
 gaiad_bin: "{{ gaiad_user_home }}/go/bin/gaiad"
 gaiad_service_name: "gaiad"
 gaiad_gov_testing: false

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -7,6 +7,8 @@ gaiad_home_autoclear: false
 gaiad_unsafe_reset: false
 gaiad_version: v7.0.0
 gaiad_repository: https://github.com/cosmos/gaia.git
+gaiad_binary_release: "https://github.com/cosmos/gaia/releases/download/v7.0.2/gaiad-{{ gaiad_version }}-linux-amd64"
+gaiad_binary_source: build
 gaiad_bin: "{{ gaiad_user_home }}/go/bin/gaiad"
 gaiad_service_name: "gaiad"
 gaiad_gov_testing: false

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -115,7 +115,7 @@
   ignore_errors: true
 
 ## Create go bin directory
-- name: Prepare cosmovisor folder
+- name: Prepare go folder
   when: gaiad_binary_source == "release"
   file:
     path: '{{ gaiad_user_home }}/go/bin'

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -114,7 +114,18 @@
   register: gaiad_current_version
   ignore_errors: true
 
-- name: Download gaiad binary from release download
+## Creatre go bin directory
+- name: Prepare cosmovisor folder
+  when: gaiad_binary_source == "release"
+  file:
+    path: '{{ gaiad_user_home }}/go/bin'
+    state: directory
+    recurse: true
+    owner: '{{gaiad_user}}'
+    group: '{{gaiad_user}}'
+
+
+- name: Download gaiad binary from release
   when: not gaiad_version in gaiad_current_version.stdout and gaiad_binary_source == "release"
   get_url:
     url: "{{ gaiad_binary_release }}"

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -114,7 +114,7 @@
   register: gaiad_current_version
   ignore_errors: true
 
-## Creatre go bin directory
+## Create go bin directory
 - name: Prepare cosmovisor folder
   when: gaiad_binary_source == "release"
   file:

--- a/roles/gaia/tasks/main.yml
+++ b/roles/gaia/tasks/main.yml
@@ -114,8 +114,17 @@
   register: gaiad_current_version
   ignore_errors: true
 
+- name: Download gaiad binary from release download
+  when: not gaiad_version in gaiad_current_version.stdout and gaiad_binary_source == "release"
+  get_url:
+    url: "{{ gaiad_binary_release }}"
+    dest: "{{gaiad_user_home}}/go/bin/gaiad"
+    mode: "0777"
+    force: true
+  become_user: "{{gaiad_user}}"
+
 - name: Clone gaiad
-  when: not gaiad_version in gaiad_current_version.stdout
+  when: not gaiad_version in gaiad_current_version.stdout and gaiad_binary_source == "build"
   git:
     repo: "{{gaiad_repository}}"
     dest: "{{ gaiad_user_home }}/gaia"
@@ -124,7 +133,7 @@
   become_user: "{{gaiad_user}}"
 
 - name: Install gaiad
-  when: not gaiad_version in gaiad_current_version.stdout
+  when: not gaiad_version in gaiad_current_version.stdout and gaiad_binary_source == "build"
   shell: |
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
     make install


### PR DESCRIPTION
PR will allow downloading pre-compiled binaries from the source chain's repo instead of compiling them.
Closes #122 

New variables added:

### gaiad_binary_source
**values:**
`build` (default) will compile a gaiad binary as it did before
`release` will download the gaiad binary from the git repo based on `gaiad_version` and `gaiad_binary_release`

### gaiad_binary_release
url to release binary. Uses `gaiad_version` to target bin
**value:** string
