### PR TITLE
Check key exists before setting

### DIFF
--- a/roles/gaia/files/copy_config_vars.py
+++ b/roles/gaia/files/copy_config_vars.py
@@ -59,7 +59,8 @@ def set_nested(nested_dict, path, value):
     final_field = segments.pop()
     current_val = nested_dict
     for subpath in segments:
-        current_val = current_val[subpath]
+        if subpath in current_val:
+            current_val = current_val[subpath]
     current_val[final_field] = value
 
 


### PR DESCRIPTION
Ran into this issue in some config where key `subpath` was missing in `current_val`. This make sure the key is there before setting it.