### PR TITLE
use [[ .. ]] and wrap in ""

### DIFF
--- a/tests/test_block_production.sh
+++ b/tests/test_block_production.sh
@@ -17,7 +17,7 @@ fi
 gaiad_version=$(curl -s http://$gaia_host:$gaia_port/abci_info | jq -r .result.response.version)
 echo $gaiad_version
 cur_height=0
-until [ ${cur_height} -gt 1 ]
+until [[ "${cur_height}" -gt 1 ]]
 do
     cur_height=$(curl -s http://$gaia_host:$gaia_port/block | jq -r .result.block.header.height)
     echo $cur_height


### PR DESCRIPTION
Fixes #140 

`cur_height` gets set to null when curl fails.

This causes the error
```
tests/test_block_production.sh: line 20: [: null: integer expression expected
null
```

By wrapping cur_height in `"`, it will be an empty string
`[` will also fail as it expects an integer. `[[` will process the value better when using `"`
