### PR TITLE
Add support for different architecture

### DIFF
--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -25,6 +25,10 @@ gaiad_airdrop: false
 gaiad_airdrop_coins: "1000000000{{ gaiad_bond_denom }}"
 gaiad_airdrop_accounts: []
 
+binary_arch_map:
+  aarch64: "linux-arm64"
+  x86_64: "linux-amd64"
+
 # Cosmovisor settings
 ## TODO: Support arbitrary cosmovisor branches
 use_cosmovisor: true
@@ -36,7 +40,7 @@ cosmovisor_service_name: "cosmovisor"
 cosmovisor_skip_backup: true
 
 # Go configuration
-go_arch: "linux-amd64"
+go_arch: "{{binary_arch_map[ansible_architecture]}}"
 go_version: "1.18.1"
 
 ## config.toml variables

--- a/roles/gaia/defaults/main.yml
+++ b/roles/gaia/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+binary_arch_map:
+  aarch64: "linux-arm64"
+  x86_64: "linux-amd64"
+
 # General Gaiad settings
 gaiad_user: gaia
 gaiad_user_home: "/home/{{gaiad_user}}"
@@ -7,7 +11,7 @@ gaiad_home_autoclear: false
 gaiad_unsafe_reset: false
 gaiad_version: v7.0.0
 gaiad_repository: https://github.com/cosmos/gaia.git
-gaiad_binary_release: "https://github.com/cosmos/gaia/releases/download/{{ gaiad_version }}/gaiad-{{ gaiad_version }}-linux-amd64"
+gaiad_binary_release: "https://github.com/cosmos/gaia/releases/download/{{ gaiad_version }}/gaiad-{{ gaiad_version }}-{{binary_arch_map[ansible_architecture]}}"
 gaiad_binary_source: "build"
 gaiad_bin: "{{ gaiad_user_home }}/go/bin/gaiad"
 gaiad_service_name: "gaiad"
@@ -26,10 +30,6 @@ gaiad_validator_coins: "1000000000000{{ gaiad_bond_denom }}"
 gaiad_airdrop: false
 gaiad_airdrop_coins: "1000000000{{ gaiad_bond_denom }}"
 gaiad_airdrop_accounts: []
-
-binary_arch_map:
-  aarch64: "linux-arm64"
-  x86_64: "linux-amd64"
 
 # Cosmovisor settings
 ## TODO: Support arbitrary cosmovisor branches


### PR DESCRIPTION
Fixes #142 

Added map for linux arch = binary name and auto selection of go arch binary (go_arch)

Closes #143 as well