### PR TITLE
Remove system Go installation

### DIFF
--- a/roles/gaia/tasks/install_gaiad.yml
+++ b/roles/gaia/tasks/install_gaiad.yml
@@ -1,6 +1,11 @@
 ---
 
-- name: Remove system Go installation
+- name: Remove golang apt package
+  ansible.builtin.apt:
+    name: golang
+    state: absent
+
+- name: Remove system Go files
   file:
     state: absent
     path: "{{ item }}"

--- a/roles/gaia/tasks/install_gaiad.yml
+++ b/roles/gaia/tasks/install_gaiad.yml
@@ -1,4 +1,13 @@
 ---
+
+- name: Remove system Go installation
+  file:
+    state: absent
+    path: "{{ item }}"
+  loop:
+    - /usr/bin/go
+    - /usr/lib/go
+
 - name: Check golang version
   shell: |
     PATH=$PATH:/usr/local/go/bin:$HOME/go/bin


### PR DESCRIPTION
Ported from [`d7acfca` (#159)](https://github.com/hyphacoop/cosmos-ansible/pull/159/commits/d7acfca2cfcc7e662b2b8042231eaa875152ee1f)

This is important for CI, as GitHub `ubuntu-latest` now includes Go 1.17. Due to the way the PATH is set up, that Go will be used even after our version is installed. This removes system Go to prevent any confusion, and enforce the version we want.