### PR TITLE
Fix/multi node genesis

### DIFF
--- a/examples/inventory-multi-node.yml
+++ b/examples/inventory-multi-node.yml
@@ -53,15 +53,19 @@ all:
           panic_is_validator: 'yes'
         sen1.cosmostest.network:
           api_enabled: true
+          sync_multinode_genesis: true
         sen2.cosmostest.network:
           api_enabled: true
+          sync_multinode_genesis: true
         sync1.cosmostest.network:
           statesync_snapshot_interval: 1000
           statesync_snapshot_keep_recent: 2
           p2p_upnp: true
           api_enabled: true
+          sync_multinode_genesis: true
         sync2.cosmostest.network:
           statesync_snapshot_interval: 1000
           statesync_snapshot_keep_recent: 2
           p2p_upnp: true
           api_enabled: true
+          sync_multinode_genesis: true

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -199,4 +199,5 @@ binary_arch_map:
 
 # Multi-validator deployment
 start_multinode: false
+sync_multinode_genesis: false
 dynamic_p2p_persistent_peers: false

--- a/roles/node/tasks/config.yml
+++ b/roles/node/tasks/config.yml
@@ -5,7 +5,7 @@
   register: ansible_runner_home
 
 - name: create SSH keypair for multi node sync
-  when: start_multinode
+  when: start_multinode or sync_multinode_genesis
   community.crypto.openssh_keypair:
     path: "{{ ansible_runner_home.stdout }}/.ssh/id_rsa"
     type: rsa
@@ -13,13 +13,13 @@
   delegate_to: "{{ genesis_node }}"
 
 - name: store SSH pubkey in variable
-  when: start_multinode
+  when: start_multinode or sync_multinode_genesis
   shell: "cat {{ ansible_runner_home.stdout }}/.ssh/id_rsa.pub"
   register: ssh_pub_key
   delegate_to: "{{ genesis_node }}"
 
 - name: add generated SSH key to multi nodes
-  when: start_multinode
+  when: start_multinode or sync_multinode_genesis
   authorized_key:
     user: "{{ ansible_user }}"
     state: present
@@ -224,7 +224,7 @@
 
 # Transfer genesis and required files to multi-node machines
 - name: Transfer multi-node config/genesis.json
-  when: start_multinode
+  when: start_multinode or sync_multinode_genesis
   synchronize:
     mode: push
     src: "{{ chain_home }}/config/genesis.json"


### PR DESCRIPTION
Added `sync_multinode_genesis` which allows non-validator nodes to sync the genesis file as `start_multinode` will create a validator.