### PR TITLE
Consensus monitor role

### DIFF
--- a/consensus-monitor.yml
+++ b/consensus-monitor.yml
@@ -1,0 +1,6 @@
+---
+# Configure a bigdipper node
+- hosts: consensus
+  become: true
+  roles:
+  - consensus-monitor

--- a/docs/Playbook-Variables.md
+++ b/docs/Playbook-Variables.md
@@ -129,7 +129,7 @@ ansible-playbook node.yml -i examples/inventory-local.yml --extra-vars "chain_ve
 | Variable                   | Description                                                      | Example Value                      |
 |----------------------------|------------------------------------------------------------------|------------------------------------|
 | `chain_id`                 |                                                                  | `theta-testnet-001`                |
-| `bdjuno_version`           | A `bdjuno` branch that matches the tracked chain                 | `chains/cosmmos/testnet`           |
+| `bdjuno_version`           | A `bdjuno` branch that matches the tracked chain                 | `chains/cosmos/testnet`            |
 | `bdjuno_rpc_address`       | The RPC address `bdjuno` will collect block data from            | `http://archive.testnet.com:26657` |
 | `bdjuno_grpc_address`      | The gRPC address `bdjuno` will collect block data from           | `http://archive.testnet.com:9090`  |
 | `bdjuno_fast_sync`         | Blocks close to genesis time will not be parsed if set to `true` | `false`                            |
@@ -144,3 +144,14 @@ ansible-playbook node.yml -i examples/inventory-local.yml --extra-vars "chain_ve
 | `bdui_host`                | Subdomain for Big Dipper UI                                      | `"explorer."`                      |
 | `bdui_icon`                | URL for the chain icon                                           |                                    |
 | `bdui_logo`                | URL for the splash logo                                          |                                    |
+
+## Consensus Monitor
+
+| Variable                    | Description                                                    | Example Value                   |
+|-----------------------------|----------------------------------------------------------------|---------------------------------|
+| `consensus_monitor_version` | `cosmos-consensus-monitor` version to use                      | `v1.0.0`                        |
+| `consensus_api_node_url`    | Node API endpoint                           | `http://node.testnet.com:26657` |
+| `consensus_rpc_node_url`    | Node RPC endpoint                           | `http://node.testnet.com:1317`  |
+| `consensus_ws_node_url`     | Port for the Websockets server                                 | `9002`                          |
+| `consensus_ui_node_url`     | Port for the web UI server                                     | `8000`                          |
+| `consensus_host`            | Subdomain to prefix the inventory hostname, requires DNS setup | `consensus.`                    |

--- a/examples/README.md
+++ b/examples/README.md
@@ -260,3 +260,22 @@ ansible-playbook bigdipper.yml -i examples/inventory-bigdipper.yml -e 'target=BI
 
 - See the Big Dipper section in the [Playbook Variables](/docs/Playbook-Variables.md) page for additional configuration options.
 - Visit the Big Dipper [docs site](https://docs.bigdipper.live/) if you want to modify the role and are looking for more information.
+
+## Set up a Consensus Monitor
+
+Deploy a node that monitors the consensus process on an existing chain. 
+
+* **Inventory file:** [`inventory-consensus.yml`](inventory-consensus.yml)
+
+### Requirements
+
+* An online node with RPC and API endpoints available (usually ports 26657 and 1317, respectively).
+
+### Run the playbook 
+
+```
+ansible-playbook consensus-monitor.yml -i examples/inventory-consensus.yml -e 'target=SERVER_IP_OR_DOMAIN consensus_api_node_url=NODE_ADDRESS:API_PORT consensus_rpc_node_url=NODE_ADDRESS:RPC_PORT'
+```
+
+- The consensus monitor interface can now be reached at `SERVER_IP_OR_DOMAIN`.
+- The Websockets server can now be reached at `SERVER_IP_OR_DOMAIN/ws/`.

--- a/examples/inventory-consensus.yml
+++ b/examples/inventory-consensus.yml
@@ -1,0 +1,14 @@
+---
+# yamllint disable rule:line-length
+
+all:
+  vars:
+    ansible_user: root
+    consensus_use_tls_proxy: false  # Enables TLS, requires a domain name
+    # letsencrypt_email: "example@example.com"  # Required for TLS setup
+  children:
+    consensus:
+      hosts:
+        "{{ target }}":
+          consensus_api_node_url: "http://online-node.example.com:1317"
+          consensus_rpc_node_url: "http://online-node.example.com:26657"

--- a/roles/consensus-monitor/defaults/main.yml
+++ b/roles/consensus-monitor/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# User and repo settings
+consensus_user: consensus
+consensus_user_home: "/home/{{ consensus_user }}"
+consensus_repo_path: "{{ consensus_user_home }}/cosmos-consensus-monitor"
+consensus_repo_url: "https://github.com/hyphacoop/cosmos-consensus-monitor.git"
+consensus_monitor_version: v1.0.0
+
+# Consensus monitor settings
+consensus_api_node_url: "http://localhost:1317"
+consensus_rpc_node_url: "http://localhost:26657"
+consensus_ws_port: 9001
+consensus_ui_port: 8000
+consensus_ws_service_name: consensus-monitor-ws
+consensus_ui_service_name: consensus-monitor-ui
+
+# Nginx / SSL settings
+consensus_setup_nginx: true
+consensus_host: ""
+consensus_use_tls_proxy: false
+ssl_provider: ""
+# nginx_sites: {}
+nginx_sites:
+  "{{ consensus_host }}{{ inventory_hostname }}":
+    ssl_provider: "{{ ssl_provider }}"
+    web_hostname: "{{ consensus_host }}{{inventory_hostname}}"
+    locations:
+      "/":
+        proxy_location: "http://127.0.0.1:{{ consensus_ui_port }}"
+        proxy_websocket: true
+      "/ws/":
+        proxy_location: "http://127.0.0.1:{{ consensus_ws_port }}"
+        proxy_websocket: true

--- a/roles/consensus-monitor/tasks/base.yml
+++ b/roles/consensus-monitor/tasks/base.yml
@@ -1,0 +1,66 @@
+---
+- name: Populate service facts
+  service_facts:
+
+- include_role:
+    name: common
+
+# Set up nginx
+- name: Change vars for TLS
+  when: consensus_setup_nginx and consensus_use_tls_proxy
+  set_fact:
+    ssl_provider: "letsencrypt"
+
+- include_role:
+    name: hypha.common.nginx
+  when: consensus_setup_nginx
+
+- include_role:
+    name: hypha.common.ssl
+  when: consensus_setup_nginx and consensus_use_tls_proxy
+
+- name: Restart nginx to apply new config
+  systemd:
+    state: restarted
+    name: nginx
+  when: consensus_setup_nginx
+
+- name: Stop existing Websockets service
+  when: >
+    (consensus_ws_service_name in ansible_facts.services) or
+    ((consensus_ws_service_name + '.service') in ansible_facts.services)
+  systemd:
+    state: stopped
+    name: "{{consensus_ws_service_name}}"
+  tags:
+    - consensus_stop
+    - consensus_restart
+  ignore_errors: true
+
+- name: Stop existing UI service
+  when: >
+    (consensus_ui_service_name in ansible_facts.services) or
+    ((consensus_ui_service_name + '.service') in ansible_facts.services)
+  systemd:
+    state: stopped
+    name: "{{consensus_ui_service_name}}"
+  tags:
+    - consensus_stop
+    - consensus_restart
+  ignore_errors: true
+
+- name: Install python
+  apt:
+    pkg:
+      - python3
+      - python3-venv
+      - python3-pip
+      - python-is-python3
+
+- name: Create consensus user
+  user:
+    name: "{{ consensus_user }}"
+    append: true
+    groups: adm
+    shell: /bin/bash
+    comment: User for consensus monitor services

--- a/roles/consensus-monitor/tasks/consensus.yml
+++ b/roles/consensus-monitor/tasks/consensus.yml
@@ -1,0 +1,71 @@
+---
+- name: Checkout cosmos-consensus-monitor repo
+  git:
+    repo: "{{ consensus_repo_url }}"
+    dest: "{{ consensus_repo_path }}"
+    version: "{{ consensus_monitor_version }}"
+    force: yes
+  become_user: "{{ consensus_user }}"
+
+- name: Set up python virtual environment
+  shell: |
+    cd {{ consensus_repo_path }}
+    python -m venv .env
+  become_user: "{{ consensus_user }}"
+
+- name: Install consensus dependencies
+  pip:
+    requirements: "{{ consensus_repo_path }}/requirements.txt"
+    virtualenv: "{{ consensus_repo_path }}/.env"
+  become_user: "{{ consensus_user }}"
+
+- name: Configure Websockets endpoint in client Javascript
+  replace:
+    path: "{{ consensus_repo_path }}/client/js/consensus.js"
+    regexp: '":" \+ \"9001\" \+ \"/\"'
+    replace: '"/ws/"'
+  become_user: "{{ consensus_user }}"
+
+- name: Configure Websockets service
+  template:
+    src: consensus-monitor-ws.service.j2
+    dest: "/etc/systemd/system/{{ consensus_ws_service_name }}.service"
+
+- name: Configure UI service
+  template:
+    src: consensus-monitor-ui.service.j2
+    dest: "/etc/systemd/system/{{ consensus_ui_service_name }}.service"
+
+- name: Enable Websockets service
+  systemd:
+    daemon_reload: true
+    state: stopped
+    enabled: true
+    name: "{{ consensus_ws_service_name }}"
+
+- name: Start Websockets service
+  systemd:
+    daemon_reload: true
+    state: started
+    enabled: true
+    name: "{{ consensus_ws_service_name }}"
+  tags:
+    - consensus_start
+    - consensus_restart
+
+- name: Enable UI service
+  systemd:
+    daemon_reload: true
+    state: stopped
+    enabled: true
+    name: "{{ consensus_ui_service_name }}"
+
+- name: Start UI service
+  systemd:
+    daemon_reload: true
+    state: started
+    enabled: true
+    name: "{{ consensus_ui_service_name }}"
+  tags:
+    - consensus_start
+    - consensus_restart

--- a/roles/consensus-monitor/tasks/main.yml
+++ b/roles/consensus-monitor/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Base setup
+  import_tasks: base.yml
+
+- name: Consensus monitor setup
+  import_tasks: consensus.yml

--- a/roles/consensus-monitor/templates/consensus-monitor-ui.service.j2
+++ b/roles/consensus-monitor/templates/consensus-monitor-ui.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description="Cosmos Monitor UI Service"
+After=network-online.target
+
+[Service]
+User={{ consensus_user }}
+WorkingDirectory={{ consensus_repo_path }}/client
+ExecStart={{ consensus_repo_path }}/.env/bin/python -m http.server {{ consensus_ui_port }}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/consensus-monitor/templates/consensus-monitor-ws.service.j2
+++ b/roles/consensus-monitor/templates/consensus-monitor-ws.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description="Cosmos Monitor Websockets Service"
+After=network-online.target
+
+[Service]
+User={{ consensus_user }}
+WorkingDirectory={{ consensus_repo_path }}/server
+ExecStart={{ consensus_repo_path }}/.env/bin/python consensus_monitor_server.py -a {{ consensus_api_node_url }} -r {{ consensus_rpc_node_url }} -p {{ consensus_ws_port }}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Adds a role to deploy the [Cosmos consensus monitor](https://github.com/hyphacoop/cosmos-consensus-monitor).
- Tested with and without TLS:
  ```
  ansible-playbook consensus-monitor.yml -i examples/inventory-consensus.yml -e 'target=<consensus_machine> consensus_api_node_url=<theta_node_api_endpoint> consensus_rpc_node_url=<theta_node_rpc_endpoint> consensus_ws_port=9005'
  ```
  ```
  ansible-playbook consensus-monitor.yml -i examples/inventory-consensus.yml -e 'target=<consensus_machine> consensus_api_node_url=<theta_node_api_endpoint> consensus_rpc_node_url=<theta_node_rpc_endpoint> consensus_ws_port=9002 consensus_use_tls_proxy=true letsencrypt_email=<email_address>'
  ```
- Closes #125 
