### PR TITLE
Fix denom replacement behaviour

### DIFF
--- a/roles/node/tasks/config.yml
+++ b/roles/node/tasks/config.yml
@@ -251,8 +251,8 @@
 - name: patch genesis file with specified denom
   replace:
     path: '{{chain_home}}/config/genesis.json'
-    regexp: 'stake'
-    replace: '{{chain_denom}}'
+    regexp: '"stake"'
+    replace: '"{{chain_denom}}"'
 
 # Transfer genesis and required files to multi-node machines
 - name: Transfer multi-node config/genesis.json

--- a/roles/node/templates/cosmovisor.service.j2
+++ b/roles/node/templates/cosmovisor.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 User={{node_user}}
-ExecStart={{ cosmovisor_bin }} start {{ cosmovisor_invariants_flag }}--home {{ chain_home }}
+ExecStart={{ cosmovisor_bin }} start {{ cosmovisor_invariants_flag }} --home {{ chain_home }}
 Restart=always
 RestartSec=3
 LimitNOFILE=4096


### PR DESCRIPTION
The node role has a task to replace the denom in the genesis file. The current implementation can lead to broken genesis files if the new denom includes the string `stake` in it.