### PR TITLE
show error messages nicer

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 host_key_checking = False
 allow_world_readable_tmpfiles = true
+stdout_callback = "yaml"


### PR DESCRIPTION
This will fix the `\n` messages in the Ansible outputs.