### PR TITLE
Add minimal setup-monitoring playbook

### DIFF
--- a/setup-monitoring.yml
+++ b/setup-monitoring.yml
@@ -1,0 +1,15 @@
+---
+# Minimal playbook to ONLY setup monitoring without touching the chain
+- hosts: node
+  become: true
+  tasks:
+    - name: Setup node-exporter
+      include_role:
+        name: node-exporter
+
+    - name: Setup on prometheus server
+      include_role:
+        name: configure-prometheus
+        apply:
+          delegate_to: "{{ grafana_ssh_url }}"
+      when: monitoring_prometheus | default(false) | bool


### PR DESCRIPTION
Adds a minimal playbook that only sets up node-exporter and registers the target with the Prometheus monitoring server, without touching any chain configuration. This is useful for adding monitoring to existing running chains without disruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)