### PR TITLE
remove vault.yml from node.yml

### DIFF
--- a/node.yml
+++ b/node.yml
@@ -2,7 +2,7 @@
 # Configure a chain node
 - hosts: node
   become: true
-  vars_files:
-    - ../cosmos-configurations-private/vault.yml
+  # vars_files:
+  #   - ../cosmos-configurations-private/vault.yml
   roles:
     - node


### PR DESCRIPTION
Remove `vault.yml` from vars_files to avoid prompting for vault password while deploying node